### PR TITLE
ci: bump golangci-lint to v2.11.4 for Go 1.25 support

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,44 @@
+version: "2"
+
+linters:
+  exclusions:
+    # v1 applied these presets and path excludes by default; v2 makes
+    # them opt-in. Keeping the v1 behavior so this bump surfaces no
+    # new findings that v1 had suppressed.
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - vendor
+      - third_party
+      - testdata
+      - examples
+      - Godeps
+      - builtin
+
+  settings:
+    staticcheck:
+      # Disable the QF (quick-fix) and ST (style) check categories.
+      # In golangci-lint v1 these were off by default (QF was opt-in,
+      # ST lived in the separate `stylecheck` linter which was also
+      # disabled by default). v2 bundles them into `staticcheck` and
+      # enables them by default. Keeping parity with v1 here avoids
+      # mixing unrelated style churn into this CI bump.
+      checks:
+        - all
+        - -QF1001
+        - -QF1002
+        - -QF1003
+        - -QF1004
+        - -QF1005
+        - -QF1006
+        - -QF1007
+        - -QF1008
+        - -QF1009
+        - -QF1010
+        - -QF1011
+        - -QF1012
+        - -ST1000
+        - -ST1003
+        - -ST1016

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EMBEDMD=embedmd
 STATICCHECK=staticcheck
 # TODO decide if we need to change these names.
 README_FILES := $(shell find . -name '*README.md' | sort | tr '\n' ' ')
-GOLANGCI_LINT_VERSION=v1.64.5
+GOLANGCI_LINT_VERSION=v2.11.4
 
 LINTER=./bin/golangci-lint
 LINTER_VERSION_FILE=./bin/.golangci-lint-version-$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
SDK-2263 - first of a 7-PR sequence to remediate CVE-2026-40179 in prometheus/prometheus. v1.64.5 refuses to load modules declaring `go 1.25`, so the lint step must be upgraded before any downstream PR raises the Go floor.

- Makefile: GOLANGCI_LINT_VERSION v1.64.5 -> v2.11.4
- .golangci.yml: minimal config to preserve v1 default behavior under v2. v2 changed several defaults: exclusion presets, excluded paths, and the staticcheck bundle now includes `stylecheck` (ST*) and `staticcheck` quick-fix (QF*) rules. Restoring v1's defaults avoids mixing unrelated code churn into this CI-only bump.

Validation (both clean, 0 issues):
- GOTOOLCHAIN=go1.23.10 make lint
- GOTOOLCHAIN=go1.24.5 make lint